### PR TITLE
fix: correct license in README from MIT to ISC

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,4 +190,4 @@ Deployed via [Flux GitOps](https://fluxcd.io/). Container images are built by Gi
 
 ## License
 
-MIT
+ISC


### PR DESCRIPTION
One-liner — README said MIT, should be ISC to match package.json and LICENSE file.