### PR TITLE
debug: add overspent handler logging

### DIFF
--- a/src/webhook/handlers/overspent.ts
+++ b/src/webhook/handlers/overspent.ts
@@ -21,6 +21,11 @@ export async function handleOverspent(ctx: WebhookContext): Promise<void> {
   }
 
   const overspent = categories.filter((c) => c.available < 0);
+  logger.info('Overspent check results', {
+    totalCategories: categories.length,
+    overspentCount: overspent.length,
+    sample: categories.slice(0, 5).map((c) => ({ name: c.name, available: c.available })),
+  });
   if (overspent.length === 0) return;
 
   const date = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' });


### PR DESCRIPTION
## Summary
- Adds diagnostic logging to the overspent webhook handler to identify why alerts aren't firing despite negative balances visible in the UI

## Test plan
- [ ] Deploy, fire overspent webhook, check logs for category data

🤖 Generated with [Claude Code](https://claude.com/claude-code)