### PR TITLE
fix: always call downloadBudget to ensure fresh budget amounts

### DIFF
--- a/src/actual/client.ts
+++ b/src/actual/client.ts
@@ -35,12 +35,12 @@ export async function withActual<T>(
         serverURL: serverUrl,
         password,
       });
-      await actualApi.downloadBudget(budgetId, { password });
       initialized = true;
-      logger.info('Actual Budget initialized and synced');
-    } else {
-      await actualApi.sync();
     }
+    // Always re-download to get the latest budget amounts — sync() only
+    // syncs transactions and does not refresh the budget spreadsheet cache.
+    await actualApi.downloadBudget(budgetId, { password });
+    logger.info('Actual Budget synced');
     return fn();
   });
 }


### PR DESCRIPTION
sync() only syncs transactions and does not refresh the budget spreadsheet cache. Calling downloadBudget on every withActual invocation ensures budget amounts reflect changes made in the UI.