### PR TITLE
feat: add POST /admin/prune-transactions endpoint

### DIFF
--- a/src/actual/queries.ts
+++ b/src/actual/queries.ts
@@ -133,3 +133,26 @@ export async function syncAllAccounts(): Promise<{
 export async function allocateBudget(month: string, categoryId: string, amount: number): Promise<void> {
   await actualApi.setBudgetAmount(month, categoryId, amount);
 }
+
+export async function pruneTransactions(
+  before: string,
+  dryRun: boolean
+): Promise<{ deleted: number; dryRun: boolean; sample: string[] }> {
+  const result = await actualApi.runQuery(
+    actualApi.q('transactions')
+      .filter({ date: { $lt: before } })
+      .options({ splits: 'none' })
+      .select(['id', 'date', 'payee', 'amount'])
+  );
+  const rows = (result as { data: Array<{ id: string; date: string; payee: string; amount: number }> }).data;
+
+  const sample = rows.slice(0, 5).map((r) => `${r.date} ${r.payee ?? '(no payee)'} $${(r.amount / 100).toFixed(2)}`);
+
+  if (!dryRun) {
+    for (const row of rows) {
+      await actualApi.deleteTransaction(row.id);
+    }
+  }
+
+  return { deleted: rows.length, dryRun, sample };
+}

--- a/src/webhook/server.ts
+++ b/src/webhook/server.ts
@@ -2,6 +2,8 @@ import express, { Request, Response } from 'express';
 import { verifySignature } from './hmac';
 import { dispatchCheckType } from './handlers/index';
 import { exportTargets, importTargets, type TargetExport } from '../db/targets';
+import { pruneTransactions } from '../actual/queries';
+import { withActual } from '../actual/client';
 import { getAppContext } from '../agent/index';
 import { logger } from '../logger';
 
@@ -75,6 +77,29 @@ export function createWebhookServer(ctx: WebhookContext) {
     const count = importTargets(db, data);
     logger.info('Budget targets imported via API', { count });
     res.json({ imported: count });
+  });
+
+  app.post('/admin/prune-transactions', (req: Request & { rawBody?: Buffer }, res: Response) => {
+    const sig = req.headers['x-webhook-signature'] as string | undefined;
+    const body = req.rawBody?.toString('utf-8') ?? '';
+    if (!sig || !verifySignature(ctx.hmacKey, body, sig)) {
+      logger.warn('Prune transactions signature invalid');
+      res.status(401).json({ error: 'invalid signature' });
+      return;
+    }
+    const { before, dryRun = true } = req.body as { before?: string; dryRun?: boolean };
+    if (!before || !/^\d{4}-\d{2}-\d{2}$/.test(before)) {
+      res.status(400).json({ error: 'Invalid payload — expected { before: "YYYY-MM-DD", dryRun: true|false }' });
+      return;
+    }
+    res.json({ accepted: true, before, dryRun });
+    withActual(ctx.dataDir, ctx.budgetId, ctx.actualServerUrl, ctx.actualPassword, () =>
+      pruneTransactions(before, dryRun)
+    ).then((result) => {
+      logger.info('Prune transactions complete', result);
+    }).catch((err: unknown) => {
+      logger.error('Prune transactions failed', { err: String(err) });
+    });
   });
 
   app.post('/webhook', (req: Request & { rawBody?: Buffer }, res: Response) => {


### PR DESCRIPTION
## Summary
- Adds HMAC-authenticated `POST /admin/prune-transactions` endpoint
- Accepts `{ before: "YYYY-MM-DD", dryRun: true|false }`
- Dry run returns count + sample without deleting
- Live run deletes all transactions before the cutoff date via the Actual Budget API

## Test plan
- [ ] Dry run with `dryRun: true` to verify count
- [ ] Live run with `dryRun: false` to execute deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)