### PR TITLE
fix: yield after every op to prevent liveness probe failures during cleanup

### DIFF
--- a/src/actual/queries.ts
+++ b/src/actual/queries.ts
@@ -193,19 +193,17 @@ export async function pruneTransactions(
     const earliestMonth = `${ey}-${String(em).padStart(2, '0')}`;
     const monthsToZero = getMonthRange(earliestMonth, lastZeroedMonth);
 
-    // Delete transactions — yield every 10 ops with a 50ms sleep to keep liveness probes happy
+    // Delete transactions — yield after every op so the HTTP server stays responsive
     for (let i = 0; i < rows.length; i++) {
       await actualApi.deleteTransaction(rows[i].id);
-      if (i % 10 === 9) await new Promise((r) => setTimeout(r, 50));
+      await new Promise((r) => setImmediate(r));
     }
 
     // Zero out budget allocations for all months up through lastZeroedMonth
-    let opCount = 0;
     for (const month of monthsToZero) {
       for (const catId of allCategoryIds) {
         await actualApi.setBudgetAmount(month, catId, 0);
-        opCount++;
-        if (opCount % 10 === 0) await new Promise((r) => setTimeout(r, 50));
+        await new Promise((r) => setImmediate(r));
       }
     }
 


### PR DESCRIPTION
## Summary
- Yields after every `deleteTransaction` and `setBudgetAmount` call using `setImmediate` instead of batching every 10 ops with a 50ms sleep
- Batching still left windows where individual slow API calls could starve the event loop beyond the 1s probe timeout
- `setImmediate` ensures the HTTP server gets a macrotask slot between every single operation

The liveness probe tolerance is also raised in the hops repo (timeoutSeconds: 5, failureThreshold: 10) as a belt-and-suspenders measure.

## Test plan
- [x] All existing unit tests pass
- [x] Deploy and run `cleanup_budget` with dry_run=false — pod should not restart mid-cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)