### PR TITLE
Fix: show payee names instead of GUIDs in cleanup preview

### DIFF
--- a/src/actual/queries.ts
+++ b/src/actual/queries.ts
@@ -177,8 +177,11 @@ export async function pruneTransactions(
     category: string | null; account: string;
   }> }).data;
 
+  const payees = await actualApi.getPayees() as Array<{ id: string; name: string }>;
+  const payeeMap = Object.fromEntries(payees.map(p => [p.id, p.name]));
+
   const sample = rows.slice(0, 5).map(
-    (r) => `${r.date} ${r.payee ?? '(no payee)'} $${(r.amount / 100).toFixed(2)}`
+    (r) => `${r.date} ${payeeMap[r.payee] ?? r.payee ?? '(no payee)'} $${(r.amount / 100).toFixed(2)}`
   );
 
   if (dryRun) {

--- a/tests/unit/actual/queries.maintenance.test.ts
+++ b/tests/unit/actual/queries.maintenance.test.ts
@@ -16,6 +16,7 @@ vi.mock('../../../src/actual/client', () => {
     actualApi: {
       getCategoryGroups: vi.fn(),
       getAccounts: vi.fn(),
+      getPayees: vi.fn().mockResolvedValue([]),
       runQuery: vi.fn(),
       q: vi.fn(() => mockChain),
       deleteCategory: vi.fn(),


### PR DESCRIPTION
## Summary
The cleanup preview sample transactions were showing raw payee UUIDs instead of names. The Actual API `q('transactions')` query returns payee as an ID — now resolves via `getPayees()` before formatting.

## Before
`2024-04-30 382addc8-39a7-48f0-9d6a-4ae627f4e3d6 $-9.25`

## After
`2024-04-30 Aldi $-9.25`

## Test plan
- [x] All 119 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)