### PR TITLE
feat: stale pending transaction detection

### DIFF
--- a/src/actual/stale-pending.ts
+++ b/src/actual/stale-pending.ts
@@ -1,0 +1,199 @@
+import { actualApi } from './client';
+import { sanitizeObject } from '../sanitize';
+import { getDynamicConfig } from '../config';
+import { logger } from '../logger';
+
+export interface UnclearedTransaction {
+  id: string;
+  date: string;
+  amount: number;
+  payee: string;
+  payeeName: string;
+  category: string | null;
+  categoryName: string;
+  account: string;
+  accountName: string;
+  cleared: boolean;
+}
+
+export interface ClearedCandidate {
+  id: string;
+  date: string;
+  amount: number;
+  payee: string;
+  account: string;
+}
+
+export interface StalePendingMatch {
+  pending: UnclearedTransaction;
+  cleared: ClearedCandidate;
+}
+
+/**
+ * Pure matching logic — no API calls. Exported for testing.
+ *
+ * For each uncleared transaction, find the closest cleared transaction
+ * from the same payee + account within dateWindowDays where
+ * |cleared.amount| >= |pending.amount| (tip was added, amounts are negative).
+ *
+ * Each cleared transaction can only match one pending transaction.
+ */
+export function findMatches(
+  uncleared: UnclearedTransaction[],
+  cleared: ClearedCandidate[],
+  dateWindowDays: number
+): StalePendingMatch[] {
+  const matches: StalePendingMatch[] = [];
+  const usedClearedIds = new Set<string>();
+
+  for (const pending of uncleared) {
+    const pendingDate = new Date(pending.date);
+    let bestMatch: ClearedCandidate | null = null;
+    let bestDistance = Infinity;
+
+    for (const candidate of cleared) {
+      if (usedClearedIds.has(candidate.id)) continue;
+      if (candidate.payee !== pending.payee) continue;
+      if (candidate.account !== pending.account) continue;
+
+      // Both amounts are negative (spending). Cleared should be more negative (larger spend with tip).
+      if (candidate.amount > pending.amount) continue;
+
+      const candidateDate = new Date(candidate.date);
+      const daysDiff = Math.abs(candidateDate.getTime() - pendingDate.getTime()) / (1000 * 60 * 60 * 24);
+      if (daysDiff > dateWindowDays) continue;
+
+      if (daysDiff < bestDistance) {
+        bestDistance = daysDiff;
+        bestMatch = candidate;
+      }
+    }
+
+    if (bestMatch) {
+      usedClearedIds.add(bestMatch.id);
+      matches.push({ pending, cleared: bestMatch });
+    }
+  }
+
+  return matches;
+}
+
+/**
+ * Query Actual Budget for stale uncleared transactions and their
+ * potential cleared counterparts. Returns matched pairs.
+ */
+export async function findStalePendingTransactions(): Promise<StalePendingMatch[]> {
+  const config = getDynamicConfig();
+  const ageDays = config.stalePendingAgeDays;
+  const categoryNames = config.stalePendingCategories;
+
+  // Resolve category names to IDs
+  const groups = await actualApi.getCategoryGroups() as Array<{
+    categories: Array<{ id: string; name: string }>;
+  }>;
+  const allCategories = groups.flatMap(g => g.categories);
+  const categoryIds = categoryNames
+    .map(name => allCategories.find(c => c.name.toLowerCase() === name.toLowerCase()))
+    .filter((c): c is { id: string; name: string } => c != null)
+    .map(c => c.id);
+
+  if (categoryIds.length === 0) {
+    logger.warn('No matching categories found for stale pending detection', { categoryNames });
+    return [];
+  }
+
+  // Build a category name lookup
+  const categoryMap = Object.fromEntries(allCategories.map(c => [c.id, c.name]));
+
+  // Get on-budget accounts
+  const accounts = await actualApi.getAccounts() as Array<{
+    id: string; name: string; closed: boolean; offbudget: boolean;
+  }>;
+  const onBudgetAccounts = accounts.filter(a => !a.closed && !a.offbudget);
+  const onBudgetIds = onBudgetAccounts.map(a => a.id);
+  const accountMap = Object.fromEntries(onBudgetAccounts.map(a => [a.id, a.name]));
+
+  // Get payee names for display
+  const payees = await actualApi.getPayees() as Array<{ id: string; name: string }>;
+  const payeeMap = Object.fromEntries(payees.map(p => [p.id, p.name]));
+
+  // Cutoff date: transactions older than ageDays are "stale"
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - ageDays);
+  const cutoffStr = cutoff.toISOString().slice(0, 10);
+
+  // Query uncleared transactions in target categories, older than cutoff
+  const unclearedResult = await actualApi.runQuery(
+    actualApi.q('transactions')
+      .filter({
+        cleared: false,
+        date: { $lte: cutoffStr },
+        category: { $oneof: categoryIds },
+        account: { $oneof: onBudgetIds },
+        transfer_id: null,
+      })
+      .options({ splits: 'inline' })
+      .select(['id', 'date', 'amount', 'payee', 'category', 'account', 'cleared'])
+  );
+  const unclearedRows = (unclearedResult as { data: Array<Record<string, unknown>> }).data;
+
+  if (unclearedRows.length === 0) {
+    logger.info('No stale uncleared transactions found');
+    return [];
+  }
+
+  const uncleared: UnclearedTransaction[] = unclearedRows.map(row => {
+    const sanitized = sanitizeObject(row) as Record<string, unknown>;
+    return {
+      id: String(sanitized['id']),
+      date: String(sanitized['date']),
+      amount: Number(sanitized['amount']),
+      payee: String(sanitized['payee']),
+      payeeName: payeeMap[String(row['payee'])] ?? String(sanitized['payee']),
+      category: sanitized['category'] ? String(sanitized['category']) : null,
+      categoryName: categoryMap[String(row['category'])] ?? '',
+      account: String(sanitized['account']),
+      accountName: accountMap[String(row['account'])] ?? '',
+      cleared: false,
+    };
+  });
+
+  // Query cleared transactions from those same payees/accounts in a wider window
+  // (from earliest uncleared date - dateWindow to now)
+  const earliestDate = uncleared.reduce((min, u) => u.date < min ? u.date : min, uncleared[0].date);
+  const windowStart = new Date(earliestDate);
+  windowStart.setDate(windowStart.getDate() - ageDays);
+  const windowStartStr = windowStart.toISOString().slice(0, 10);
+
+  const uniquePayeeIds = [...new Set(uncleared.map(u => u.payee))];
+  const uniqueAccountIds = [...new Set(uncleared.map(u => u.account))];
+
+  const clearedResult = await actualApi.runQuery(
+    actualApi.q('transactions')
+      .filter({
+        cleared: true,
+        date: { $gte: windowStartStr },
+        payee: { $oneof: uniquePayeeIds },
+        account: { $oneof: uniqueAccountIds },
+        transfer_id: null,
+      })
+      .options({ splits: 'inline' })
+      .select(['id', 'date', 'amount', 'payee', 'account'])
+  );
+  const clearedRows = (clearedResult as { data: Array<Record<string, unknown>> }).data;
+
+  const cleared: ClearedCandidate[] = clearedRows.map(row => ({
+    id: String(row['id']),
+    date: String(row['date']),
+    amount: Number(row['amount']),
+    payee: String(row['payee']),
+    account: String(row['account']),
+  }));
+
+  logger.info('Stale pending scan', {
+    unclearedCount: uncleared.length,
+    clearedCandidates: cleared.length,
+  });
+
+  return findMatches(uncleared, cleared, ageDays);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ export interface SecretsConfig {
   enableLlm: boolean;
   enablePayPeriodAllocation: boolean;
   enableSeedTargets: boolean;
+  enableStalePending: boolean;
   llmProvider: string;
   llmApiKey: string;
   llmModel?: string;
@@ -30,6 +31,8 @@ export interface DynamicConfig {
   proposalTtlHours: number;
   payFrequencyDays: number;
   lastPayDate: string;
+  stalePendingAgeDays: number;
+  stalePendingCategories: string[];
 }
 
 const CONFIGMAP_PATH = process.env['CONFIGMAP_PATH'];
@@ -42,12 +45,15 @@ function requireEnv(name: string): string {
 
 function envDefaults(): DynamicConfig {
   const categories = process.env['EMAIL_CATEGORIES'];
+  const stalePendingCats = process.env['STALE_PENDING_CATEGORIES'];
   return {
     overspendThresholdDollars: parseInt(process.env['OVERSPEND_THRESHOLD_DOLLARS'] ?? '50', 10),
     emailCategories: categories ? categories.split(',').map((s) => s.trim()) : ['Dining Out', 'Groceries'],
     proposalTtlHours: parseInt(process.env['PROPOSAL_TTL_HOURS'] ?? '24', 10),
     payFrequencyDays: parseInt(process.env['PAY_FREQUENCY_DAYS'] ?? '14', 10),
     lastPayDate: process.env['LAST_PAY_DATE'] ?? '2025-01-03',
+    stalePendingAgeDays: parseInt(process.env['STALE_PENDING_AGE_DAYS'] ?? '5', 10),
+    stalePendingCategories: stalePendingCats ? stalePendingCats.split(',').map((s) => s.trim()) : ['Dining Out'],
   };
 }
 
@@ -56,10 +62,12 @@ export function getSecrets(): SecretsConfig {
   const enableLlm = (process.env['ENABLE_LLM'] ?? 'true').toLowerCase() === 'true';
   const enablePayPeriodAllocation = (process.env['ENABLE_PAY_PERIOD_ALLOCATION'] ?? 'true').toLowerCase() === 'true';
   const enableSeedTargets = (process.env['ENABLE_SEED_TARGETS'] ?? 'true').toLowerCase() === 'true';
+  const enableStalePending = (process.env['ENABLE_STALE_PENDING'] ?? 'false').toLowerCase() === 'true';
   return {
     enableLlm,
     enablePayPeriodAllocation,
     enableSeedTargets,
+    enableStalePending,
     llmProvider: process.env['LLM_PROVIDER'] ?? 'anthropic',
     llmApiKey: enableLlm ? requireEnv('LLM_API_KEY') : (process.env['LLM_API_KEY'] ?? ''),
     llmModel: process.env['LLM_MODEL'] || undefined,
@@ -98,6 +106,8 @@ export function getDynamicConfig(): DynamicConfig {
       proposalTtlHours: parsed.proposalTtlHours ?? defaults.proposalTtlHours,
       payFrequencyDays: parsed.payFrequencyDays ?? defaults.payFrequencyDays,
       lastPayDate: parsed.lastPayDate ?? defaults.lastPayDate,
+      stalePendingAgeDays: parsed.stalePendingAgeDays ?? defaults.stalePendingAgeDays,
+      stalePendingCategories: parsed.stalePendingCategories ?? defaults.stalePendingCategories,
     };
   } catch (err) {
     logger.warn('Failed to read config file — using env/defaults', { path: CONFIGMAP_PATH, err: String(err) });

--- a/src/db/deletion-proposals.ts
+++ b/src/db/deletion-proposals.ts
@@ -1,0 +1,31 @@
+import type Database from 'better-sqlite3';
+import { getProposalTtl } from './proposals';
+
+export interface DeletionProposal {
+  id: string;
+  txId: string;
+  matchedTxId: string;
+  threadId: string;
+  messageId: string;
+  status: string;
+  expiresAt: number;
+}
+
+export function createDeletionProposal(
+  db: Database.Database,
+  p: Omit<DeletionProposal, 'status' | 'expiresAt'>
+): void {
+  const expiresAt = Math.floor(Date.now() / 1000) + getProposalTtl();
+  db.prepare(`
+    INSERT INTO pending_proposals (id, tx_id, category, reason, thread_id, message_id, expires_at, type, matched_tx_id)
+    VALUES (?, ?, 'deletion', 'stale pending', ?, ?, ?, 'deletion', ?)
+  `).run(p.id, p.txId, p.threadId, p.messageId, expiresAt, p.matchedTxId);
+}
+
+export function hasActiveDeletionProposal(db: Database.Database, txId: string): boolean {
+  const now = Math.floor(Date.now() / 1000);
+  const row = db.prepare(
+    "SELECT 1 FROM pending_proposals WHERE tx_id = ? AND type = 'deletion' AND status = 'pending' AND expires_at > ? LIMIT 1"
+  ).get(txId, now);
+  return row != null;
+}

--- a/src/db/proposals.ts
+++ b/src/db/proposals.ts
@@ -35,7 +35,7 @@ export function createProposal(
 
 export function getPendingProposals(db: Database.Database): Proposal[] {
   return (
-    db.prepare("SELECT * FROM pending_proposals WHERE status = 'pending'").all() as Array<{
+    db.prepare("SELECT * FROM pending_proposals WHERE status = 'pending' AND (type = 'category' OR type IS NULL)").all() as Array<{
       id: string; tx_id: string; category: string; reason: string;
       thread_id: string; message_id: string; status: string; expires_at: number;
     }>
@@ -48,7 +48,7 @@ export function getPendingProposals(db: Database.Database): Proposal[] {
 export function hasActiveProposal(db: Database.Database, txId: string): boolean {
   const now = Math.floor(Date.now() / 1000);
   const row = db.prepare(
-    "SELECT 1 FROM pending_proposals WHERE tx_id = ? AND status = 'pending' AND expires_at > ? LIMIT 1"
+    "SELECT 1 FROM pending_proposals WHERE tx_id = ? AND status = 'pending' AND (type = 'category' OR type IS NULL) AND expires_at > ? LIMIT 1"
   ).get(txId, now);
   return row != null;
 }
@@ -56,7 +56,7 @@ export function hasActiveProposal(db: Database.Database, txId: string): boolean 
 export function getActiveProposal(db: Database.Database, txId: string): Proposal | null {
   const now = Math.floor(Date.now() / 1000);
   const row = db.prepare(
-    "SELECT * FROM pending_proposals WHERE tx_id = ? AND status = 'pending' AND expires_at > ? LIMIT 1"
+    "SELECT * FROM pending_proposals WHERE tx_id = ? AND status = 'pending' AND (type = 'category' OR type IS NULL) AND expires_at > ? LIMIT 1"
   ).get(txId, now) as { id: string; tx_id: string; category: string; reason: string; thread_id: string; message_id: string; status: string; expires_at: number } | undefined;
   if (!row) return null;
   return {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -22,6 +22,9 @@ const DDL_STATEMENTS = [
     expires_at   INTEGER NOT NULL,
     created_at   INTEGER NOT NULL DEFAULT (unixepoch())
   )`,
+  // Migration: add type and matched_tx_id columns to pending_proposals
+  `ALTER TABLE pending_proposals ADD COLUMN type TEXT NOT NULL DEFAULT 'category'`,
+  `ALTER TABLE pending_proposals ADD COLUMN matched_tx_id TEXT`,
   `CREATE TABLE IF NOT EXISTS budget_targets (
     category_id   TEXT PRIMARY KEY,
     category_name TEXT NOT NULL,
@@ -43,6 +46,15 @@ const DDL_STATEMENTS = [
 
 export function runMigrations(db: Database.Database): void {
   for (const sql of DDL_STATEMENTS) {
-    db.prepare(sql).run();
+    try {
+      db.prepare(sql).run();
+    } catch (err: unknown) {
+      // ALTER TABLE fails if column already exists — that's expected on restart
+      const msg = err instanceof Error ? err.message : String(err);
+      if (sql.startsWith('ALTER TABLE') && msg.includes('duplicate column')) {
+        continue;
+      }
+      throw err;
+    }
   }
 }

--- a/src/discord/interactions.ts
+++ b/src/discord/interactions.ts
@@ -83,7 +83,7 @@ export function registerInteractionHandler(
 
     const messageId = interaction.message.id;
     const proposal = db
-      .prepare("SELECT * FROM pending_proposals WHERE message_id = ? AND status = 'pending'")
+      .prepare("SELECT * FROM pending_proposals WHERE message_id = ? AND status = 'pending' AND type = 'category'")
       .get(messageId) as { id: string; tx_id: string; category: string; thread_id: string } | undefined;
 
     if (!proposal) {

--- a/src/discord/interactions.ts
+++ b/src/discord/interactions.ts
@@ -34,6 +34,53 @@ export function registerInteractionHandler(
     // Handle cleanup flow buttons
     if (await handleCleanupInteraction(interaction, client)) return;
 
+    // Handle deletion proposal buttons
+    const deletionCustomIds = ['approve_delete', 'reject_delete', 'skip_delete'];
+    if (deletionCustomIds.includes(interaction.customId)) {
+      const msgId = interaction.message.id;
+      const deletionProposal = db
+        .prepare("SELECT * FROM pending_proposals WHERE message_id = ? AND type = 'deletion' AND status = 'pending'")
+        .get(msgId) as { id: string; tx_id: string; matched_tx_id: string; thread_id: string } | undefined;
+
+      if (!deletionProposal) {
+        await interaction.reply({ content: 'This proposal has already been resolved or expired.', ephemeral: true });
+        return;
+      }
+
+      await interaction.deferUpdate();
+      const origContent = interaction.message.content;
+
+      switch (interaction.customId) {
+        case 'approve_delete':
+          try {
+            await withActual(
+              actualConfig.dataDir, actualConfig.budgetId, actualConfig.serverUrl, actualConfig.password,
+              async () => {
+                const { actualApi: api } = await import('../actual/client');
+                await api.deleteTransaction(deletionProposal.tx_id);
+              }
+            );
+            updateProposalStatus(db, deletionProposal.id, 'approved');
+            await editMessage(client, deletionProposal.thread_id, msgId, `${origContent}\n\n**Decision: ✅ Deleted**`);
+            await postToThread(client, deletionProposal.thread_id, `✅ Deleted stale pending transaction \`${deletionProposal.tx_id}\`.`);
+          } catch (err) {
+            logger.error('Delete transaction failed', { proposalId: deletionProposal.id, err: String(err) });
+            await postToThread(client, deletionProposal.thread_id, `⚠️ Failed to delete: ${String(err)}`);
+          }
+          break;
+        case 'reject_delete':
+          updateProposalStatus(db, deletionProposal.id, 'rejected');
+          await editMessage(client, deletionProposal.thread_id, msgId, `${origContent}\n\n**Decision: ❌ Rejected**`);
+          await postToThread(client, deletionProposal.thread_id, `❌ Deletion rejected for \`${deletionProposal.tx_id}\`.`);
+          break;
+        case 'skip_delete':
+          updateProposalStatus(db, deletionProposal.id, 'skipped');
+          await editMessage(client, deletionProposal.thread_id, msgId, `${origContent}\n\n**Decision: ⏭️ Skipped**`);
+          break;
+      }
+      return;
+    }
+
     const messageId = interaction.message.id;
     const proposal = db
       .prepare("SELECT * FROM pending_proposals WHERE message_id = ? AND status = 'pending'")

--- a/src/discord/threads.ts
+++ b/src/discord/threads.ts
@@ -87,6 +87,18 @@ export async function editMessage(
   }
 }
 
+export async function postDeletionApprovalMessage(
+  thread: ThreadChannel,
+  content: string
+): Promise<Message> {
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder().setCustomId('approve_delete').setLabel('Approve').setStyle(ButtonStyle.Success),
+    new ButtonBuilder().setCustomId('reject_delete').setLabel('Reject').setStyle(ButtonStyle.Danger),
+    new ButtonBuilder().setCustomId('skip_delete').setLabel('Skip').setStyle(ButtonStyle.Secondary)
+  );
+  return thread.send({ content, components: [row] });
+}
+
 /** Post a batch of Discord messages with 1-second delay between each to respect rate limits. */
 export async function postBatch(fns: Array<() => Promise<void>>): Promise<void> {
   for (let i = 0; i < fns.length; i++) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ async function main() {
   }
   if (!secrets.enablePayPeriodAllocation) logger.info('Pay-period allocation disabled (ENABLE_PAY_PERIOD_ALLOCATION is not set to true)');
   if (!secrets.enableSeedTargets) logger.info('Seed targets disabled (ENABLE_SEED_TARGETS is not set to true)');
+  if (!secrets.enableStalePending) logger.info('Stale pending detection disabled (ENABLE_STALE_PENDING is not set to true)');
 
   const actualConfig: ActualConfig = {
     dataDir: secrets.dataDir,

--- a/src/webhook/handlers/bank_sync.ts
+++ b/src/webhook/handlers/bank_sync.ts
@@ -4,6 +4,7 @@ import { syncAllAccounts } from '../../actual/queries';
 import { handleUncategorized } from './uncategorized';
 import { getAppContext } from '../../agent/index';
 import { getOrCreateThread, postToThread } from '../../discord/threads';
+import { getSecrets } from '../../config';
 import { logger } from '../../logger';
 
 export async function handleBankSync(ctx: WebhookContext): Promise<void> {
@@ -35,6 +36,11 @@ export async function handleBankSync(ctx: WebhookContext): Promise<void> {
 
   if (result.synced.length > 0) {
     await handleUncategorized(ctx);
+    const secrets2 = getSecrets();
+    if (secrets2.enableStalePending) {
+      const { handleStalePending } = await import('./stale_pending');
+      await handleStalePending(ctx);
+    }
   } else {
     logger.warn('No accounts synced successfully — skipping uncategorized check');
   }

--- a/src/webhook/handlers/bank_sync.ts
+++ b/src/webhook/handlers/bank_sync.ts
@@ -4,7 +4,6 @@ import { syncAllAccounts } from '../../actual/queries';
 import { handleUncategorized } from './uncategorized';
 import { getAppContext } from '../../agent/index';
 import { getOrCreateThread, postToThread } from '../../discord/threads';
-import { getSecrets } from '../../config';
 import { logger } from '../../logger';
 
 export async function handleBankSync(ctx: WebhookContext): Promise<void> {
@@ -36,8 +35,7 @@ export async function handleBankSync(ctx: WebhookContext): Promise<void> {
 
   if (result.synced.length > 0) {
     await handleUncategorized(ctx);
-    const secrets2 = getSecrets();
-    if (secrets2.enableStalePending) {
+    if (secrets.enableStalePending) {
       const { handleStalePending } = await import('./stale_pending');
       await handleStalePending(ctx);
     }

--- a/src/webhook/handlers/index.ts
+++ b/src/webhook/handlers/index.ts
@@ -43,6 +43,11 @@ export async function dispatchCheckType(payload: WebhookPayload, ctx: WebhookCon
       const { handleAllocatePayPeriod } = await import('./allocate_budget');
       return handleAllocatePayPeriod(ctx);
     }
+    case 'stale_pending': {
+      if (!secrets.enableStalePending) { logger.info('Skipping stale pending — disabled'); return; }
+      const { handleStalePending } = await import('./stale_pending');
+      return handleStalePending(ctx);
+    }
     default:
       logger.warn('Unknown checkType', { checkType: (payload as { checkType: string }).checkType });
   }

--- a/src/webhook/handlers/stale_pending.ts
+++ b/src/webhook/handlers/stale_pending.ts
@@ -1,0 +1,96 @@
+import type { WebhookContext } from '../server';
+import type { ThreadChannel } from 'discord.js';
+import { withActual } from '../../actual/client';
+import { findStalePendingTransactions, type StalePendingMatch } from '../../actual/stale-pending';
+import { getAppContext } from '../../agent/index';
+import { getOrCreateThread, postToThread, postDeletionApprovalMessage } from '../../discord/threads';
+import { createDeletionProposal, hasActiveDeletionProposal } from '../../db/deletion-proposals';
+import { randomUUID } from 'crypto';
+import { logger } from '../../logger';
+
+export async function handleStalePending(ctx: WebhookContext): Promise<void> {
+  const { discord, secrets, db } = getAppContext();
+
+  let matches: StalePendingMatch[];
+  try {
+    matches = await withActual(
+      ctx.dataDir, ctx.budgetId, ctx.actualServerUrl, ctx.actualPassword,
+      findStalePendingTransactions
+    );
+  } catch (err) {
+    logger.error('Actual unreachable (stale pending)', { err: String(err) });
+    const errChannel = await discord.channels.fetch(secrets.discordErrorChannelId).catch(() => null) as any;
+    await errChannel?.send('⚠️ Could not reach Actual Budget for stale pending check.').catch(() => {});
+    return;
+  }
+
+  if (matches.length === 0) {
+    logger.info('No stale pending transactions found');
+    return;
+  }
+
+  const date = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  const thread = await getOrCreateThread(
+    discord,
+    secrets.discordBudgetChannelId,
+    `Stale pending transactions — ${date}`
+  );
+
+  await postToThread(discord, thread.id,
+    `Found ${matches.length} stale pending transaction${matches.length > 1 ? 's' : ''} with cleared counterparts:`
+  );
+
+  let posted = 0;
+  for (const match of matches) {
+    if (hasActiveDeletionProposal(db, match.pending.id)) {
+      logger.info('Skipping — active deletion proposal exists', { txId: match.pending.id });
+      continue;
+    }
+
+    const pendingAmount = `$${(Math.abs(match.pending.amount) / 100).toFixed(2)}`;
+    const clearedAmount = `$${(Math.abs(match.cleared.amount) / 100).toFixed(2)}`;
+    const pendingAge = Math.floor(
+      (Date.now() - new Date(match.pending.date).getTime()) / (1000 * 60 * 60 * 24)
+    );
+
+    const content = [
+      '**Stale Pending Transaction**',
+      `Payee: **${match.pending.payeeName}**`,
+      `Account: **${match.pending.accountName}**`,
+      `Category: **${match.pending.categoryName}**`,
+      '',
+      '**Pending (to delete):**',
+      `> Date: ${match.pending.date} (${pendingAge} days ago)`,
+      `> Amount: ${pendingAmount}`,
+      `> ID: \`${match.pending.id}\``,
+      '',
+      '**Cleared (kept):**',
+      `> Date: ${match.cleared.date}`,
+      `> Amount: ${clearedAmount}`,
+      `> ID: \`${match.cleared.id}\``,
+      '',
+      `Action: **Delete pending transaction**`,
+    ].join('\n');
+
+    const threadChannel = await discord.channels.fetch(thread.id) as ThreadChannel;
+    const message = await postDeletionApprovalMessage(threadChannel, content);
+
+    const proposalId = randomUUID();
+    createDeletionProposal(db, {
+      id: proposalId,
+      txId: match.pending.id,
+      matchedTxId: match.cleared.id,
+      threadId: thread.id,
+      messageId: message.id,
+    });
+
+    posted++;
+    logger.info('Deletion proposal posted', { proposalId, txId: match.pending.id, matchedTxId: match.cleared.id });
+  }
+
+  if (posted > 0) {
+    await postToThread(discord, thread.id,
+      `Posted ${posted} deletion proposal${posted > 1 ? 's' : ''}. Approve to delete the stale pending transaction.`
+    );
+  }
+}

--- a/src/webhook/server.ts
+++ b/src/webhook/server.ts
@@ -17,7 +17,8 @@ export interface WebhookPayload {
     | 'weekly_digest'
     | 'bank_sync'
     | 'seed_targets'
-    | 'allocate_pay_period';
+    | 'allocate_pay_period'
+    | 'stale_pending';
   triggeredAt: string;
 }
 

--- a/tests/unit/actual/stale-pending.test.ts
+++ b/tests/unit/actual/stale-pending.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { findMatches, type UnclearedTransaction, type ClearedCandidate } from '../../../src/actual/stale-pending';
+
+describe('findMatches', () => {
+  const base: UnclearedTransaction = {
+    id: 'tx-1',
+    date: '2026-03-20',
+    amount: -2500, // $25.00
+    payee: 'payee-abc',
+    payeeName: "Huey's Cordova",
+    category: 'cat-dining',
+    categoryName: 'Dining Out',
+    account: 'acct-1',
+    accountName: 'Checking',
+    cleared: false,
+  };
+
+  it('matches a cleared transaction from same payee, same account, higher amount, within date window', () => {
+    const uncleared: UnclearedTransaction[] = [base];
+    const cleared: ClearedCandidate[] = [{
+      id: 'tx-2',
+      date: '2026-03-21',
+      amount: -3000, // $30.00 (with tip)
+      payee: 'payee-abc',
+      account: 'acct-1',
+    }];
+    const result = findMatches(uncleared, cleared, 3);
+    expect(result).toHaveLength(1);
+    expect(result[0].pending.id).toBe('tx-1');
+    expect(result[0].cleared.id).toBe('tx-2');
+  });
+
+  it('rejects match from different account', () => {
+    const uncleared: UnclearedTransaction[] = [base];
+    const cleared: ClearedCandidate[] = [{
+      id: 'tx-2',
+      date: '2026-03-21',
+      amount: -3000,
+      payee: 'payee-abc',
+      account: 'acct-OTHER',
+    }];
+    const result = findMatches(uncleared, cleared, 3);
+    expect(result).toHaveLength(0);
+  });
+
+  it('rejects match from different payee', () => {
+    const uncleared: UnclearedTransaction[] = [base];
+    const cleared: ClearedCandidate[] = [{
+      id: 'tx-2',
+      date: '2026-03-21',
+      amount: -3000,
+      payee: 'payee-OTHER',
+      account: 'acct-1',
+    }];
+    const result = findMatches(uncleared, cleared, 3);
+    expect(result).toHaveLength(0);
+  });
+
+  it('rejects match where cleared amount is less than pending', () => {
+    const uncleared: UnclearedTransaction[] = [base];
+    const cleared: ClearedCandidate[] = [{
+      id: 'tx-2',
+      date: '2026-03-21',
+      amount: -2000, // less than pending (less negative = smaller spend)
+      payee: 'payee-abc',
+      account: 'acct-1',
+    }];
+    const result = findMatches(uncleared, cleared, 3);
+    expect(result).toHaveLength(0);
+  });
+
+  it('rejects match outside date window', () => {
+    const uncleared: UnclearedTransaction[] = [base];
+    const cleared: ClearedCandidate[] = [{
+      id: 'tx-2',
+      date: '2026-03-28', // 8 days later, outside 3-day window
+      amount: -3000,
+      payee: 'payee-abc',
+      account: 'acct-1',
+    }];
+    const result = findMatches(uncleared, cleared, 3);
+    expect(result).toHaveLength(0);
+  });
+
+  it('handles multiple uncleared, each matched to closest cleared', () => {
+    const uncleared: UnclearedTransaction[] = [
+      { ...base, id: 'tx-1', date: '2026-03-18', amount: -2000 },
+      { ...base, id: 'tx-3', date: '2026-03-20', amount: -2500 },
+    ];
+    const cleared: ClearedCandidate[] = [
+      { id: 'tx-2', date: '2026-03-19', amount: -2400, payee: 'payee-abc', account: 'acct-1' },
+      { id: 'tx-4', date: '2026-03-21', amount: -3000, payee: 'payee-abc', account: 'acct-1' },
+    ];
+    const result = findMatches(uncleared, cleared, 3);
+    expect(result).toHaveLength(2);
+    const clearedIds = result.map(r => r.cleared.id);
+    expect(new Set(clearedIds).size).toBe(2);
+  });
+
+  it('does not reuse a cleared transaction for multiple pending', () => {
+    const uncleared: UnclearedTransaction[] = [
+      { ...base, id: 'tx-1', date: '2026-03-20', amount: -2000 },
+      { ...base, id: 'tx-3', date: '2026-03-20', amount: -2500 },
+    ];
+    const cleared: ClearedCandidate[] = [
+      { id: 'tx-2', date: '2026-03-21', amount: -3000, payee: 'payee-abc', account: 'acct-1' },
+    ];
+    const result = findMatches(uncleared, cleared, 3);
+    expect(result).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Detects stale uncleared transactions (tip-authorization ghosts) that have a matching cleared counterpart from the same payee/account with a higher amount
- Posts Discord approval cards showing both pending and cleared transaction details for manual review before deletion
- Gated behind `ENABLE_STALE_PENDING` feature flag (default: off), with configurable `STALE_PENDING_AGE_DAYS` (default: 5) and `STALE_PENDING_CATEGORIES` (default: "Dining Out")

## How it works

1. After bank sync + uncategorized check, queries for uncleared transactions older than N days in configured categories
2. For each, finds a cleared transaction from the same payee + account within the date window where cleared amount >= pending amount
3. Posts a Discord approval card with Approve/Reject/Skip buttons showing both transactions
4. On approval, deletes the stale pending transaction from Actual Budget

Also available as a standalone `stale_pending` webhook check type.

## Files changed (13 files, +535 lines)

| File | Change |
|------|--------|
| `src/config.ts` | Feature flag + dynamic config |
| `src/db/schema.ts` | `type` and `matched_tx_id` columns on `pending_proposals` |
| `src/actual/stale-pending.ts` | Detection query logic + pure matching function |
| `src/db/deletion-proposals.ts` | Deletion proposal DB helpers |
| `src/webhook/handlers/stale_pending.ts` | Webhook handler with Discord approval cards |
| `src/discord/threads.ts` | `postDeletionApprovalMessage` |
| `src/webhook/handlers/bank_sync.ts` | Chain stale pending after uncategorized |
| `src/discord/interactions.ts` | Approve/reject/skip deletion buttons |
| `src/webhook/handlers/index.ts` | Standalone webhook dispatch |
| `src/webhook/server.ts` | `stale_pending` check type |
| `src/db/proposals.ts` | Type filters to prevent cross-contamination |
| `src/index.ts` | Feature flag log line |
| `tests/unit/actual/stale-pending.test.ts` | 7 unit tests for matching logic |

## Test plan

- [x] `npm run build` — clean TypeScript compilation
- [x] `npx vitest run` — 126 tests passing (15 files), including 7 new stale-pending tests
- [ ] Deploy with `ENABLE_STALE_PENDING=true` and `STALE_PENDING_CATEGORIES=Dining Out`
- [ ] Trigger bank sync or standalone `stale_pending` webhook
- [ ] Verify Discord approval card shows both pending and cleared transaction details
- [ ] Approve a deletion and confirm the pending transaction is removed from Actual

🤖 Generated with [Claude Code](https://claude.com/claude-code)