### PR TITLE
docs(hermes): target the dedicated 'pennyworth' profile

### DIFF
--- a/SMOKE_TEST.md
+++ b/SMOKE_TEST.md
@@ -44,6 +44,6 @@ With the gateway running (`T=secret`):
 
 ## Hermes end-to-end
 
-- [ ] `hermes mcp` probe against the gateway lists the 8 budget tools.
+- [ ] `hermes -p pennyworth mcp` probe against the gateway lists the 8 budget tools.
 - [ ] Telegram: "categorize my latest transactions" → categories applied (verify in Actual web UI) + a summary in chat.
 - [ ] Telegram correction ("that one is Household, not Groceries") → re-applied in Actual; ask again later and the same payee is categorized the corrected way (memory recall).

--- a/hermes/README.md
+++ b/hermes/README.md
@@ -4,18 +4,24 @@ Connects Hermes Agent to the Actual HTTP Gateway's MCP endpoint so you can
 categorize transactions by chatting on Telegram, with Hermes' memory learning
 your corrections over time.
 
+This budget agent runs as the dedicated Hermes profile **`pennyworth`** — its own
+Hermes home (config, memory, sessions, skills, gateway state), isolated from your
+other agents. Target it by prefixing any command with `-p pennyworth`
+(`hermes -p pennyworth …`); creating the profile also exposes a `pennyworth …`
+alias if you prefer.
+
 ## Prerequisites
 - The gateway is running and reachable (REST + MCP), with `GATEWAY_TOKEN` set.
 - Ollama is running with a tool-calling model (>=64k context, e.g. a Hermes 3 variant).
-- Hermes Agent installed, with its gateway daemon running (required for Telegram + memory).
+- The `pennyworth` Hermes profile exists, with its gateway daemon running (required for Telegram + memory): `hermes -p pennyworth gateway start`.
 
 ## Steps
-1. Copy `config.yaml` and `system-prompt.md` into your Hermes config location and edit the marked values (Ollama URL/model, gateway URL, `GATEWAY_TOKEN`).
-2. Register the gateway MCP server:
-   - `hermes mcp add budget-gateway --transport http --url http://gateway:3000/mcp` (replace `gateway:3000` with your gateway host:port)
+1. Copy `config.yaml` and `system-prompt.md` into the `pennyworth` profile's config home and edit the marked values (Ollama URL/model, gateway URL, `GATEWAY_TOKEN`).
+2. Register the gateway MCP server on the profile:
+   - `hermes -p pennyworth mcp add budget-gateway --transport http --url http://gateway:3000/mcp` (replace `gateway:3000` with your gateway host:port)
    - Provide the gateway bearer token when prompted. If your Hermes version cannot send a static Authorization header to an HTTP MCP server, run the gateway MCP on the trusted homelab network and restrict `/mcp` at the network layer instead.
    - During the probe, enable exactly these 8 tools: `list_uncategorized_transactions`, `query_transactions`, `get_budget_status`, `list_categories`, `get_schedules`, `get_targets`, `get_underfunded`, `apply_category`.
-3. Pair your Telegram account (see Hermes messaging docs) and confirm unknown DMs are ignored.
+3. Pair your Telegram account to the `pennyworth` profile (see Hermes messaging docs) and confirm unknown DMs are ignored.
 4. Smoke test: DM the bot "categorize my latest transactions", confirm categories land in Actual, then correct one and confirm it re-applies and is remembered.
 
 ## Step 2 (later cycle): n8n trigger

--- a/hermes/config.yaml
+++ b/hermes/config.yaml
@@ -1,6 +1,8 @@
 # Hermes Agent configuration for the Budget Agent.
-# Copy into your Hermes Agent config location and edit the marked values.
-# Docs: https://hermes-agent.nousresearch.com/docs/
+# Copy into the `pennyworth` profile's config home (each profile is its own
+# Hermes home dir) and edit the marked values. Run/manage with `-p pennyworth`,
+# e.g. `hermes -p pennyworth gateway start`.
+# Docs: https://hermes-agent.nousresearch.com/docs/user-guide/profiles
 
 provider:
   type: ollama


### PR DESCRIPTION
## Summary

Updates the Hermes Agent config artifacts to run the budget agent as its own dedicated Hermes profile, **`pennyworth`** (a separate Hermes home — config, memory, sessions, skills, gateway state — isolated from your other agents).

- `hermes/README.md` — commands now use `hermes -p pennyworth …` (e.g. `hermes -p pennyworth mcp add budget-gateway …`, `hermes -p pennyworth gateway start`); config goes into the `pennyworth` profile home; Telegram pairs to that profile.
- `hermes/config.yaml` — header comment points at the `pennyworth` profile home + links the profiles docs.
- `SMOKE_TEST.md` — the `hermes mcp` probe check uses `-p pennyworth`.

Docs-only; no code changes. The `-p <name>` profile flag is per [Hermes Agent profiles docs](https://hermes-agent.nousresearch.com/docs/user-guide/profiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)