### PR TITLE
fix(gateway): exclude hidden categories from budget status

### DIFF
--- a/src/actual/queries.ts
+++ b/src/actual/queries.ts
@@ -107,15 +107,34 @@ export async function getTransactions(filters: {
 export async function getBudgetStatus(month?: string): Promise<CategoryStatus[]> {
   const targetMonth = month ?? new Date().toISOString().slice(0, 7);
   const data = await actualApi.getBudgetMonth(targetMonth);
+
+  // getBudgetMonth() returns every category (including hidden ones and those in
+  // hidden groups) and its objects don't reliably carry a `hidden` flag. Use
+  // getCategoryGroups() — the authoritative source for visibility, same as
+  // getCategories() — to build the set of non-hidden category ids to keep.
+  const groups = (await actualApi.getCategoryGroups()) as Array<{
+    hidden?: boolean;
+    categories?: Array<{ id: string; hidden?: boolean }>;
+  }>;
+  const visible = new Set<string>();
+  for (const g of groups) {
+    if (g.hidden) continue;
+    for (const c of g.categories ?? []) {
+      if (!c.hidden) visible.add(c.id);
+    }
+  }
+
   return (data.categoryGroups as Array<{ is_income?: boolean; categories: unknown[] }>).flatMap((g) =>
-    (g.categories as Array<Record<string, unknown>>).map((c) => ({
-      id: String(c['id']),
-      name: sanitizeObject({ name: String(c['name']) }).name,
-      budgeted: Number(c['budgeted']),
-      spent: Number(c['spent']),
-      available: Number(c['balance']),
-      isIncome: g.is_income === true,
-    }))
+    (g.categories as Array<Record<string, unknown>>)
+      .filter((c) => visible.has(String(c['id'])))
+      .map((c) => ({
+        id: String(c['id']),
+        name: sanitizeObject({ name: String(c['name']) }).name,
+        budgeted: Number(c['budgeted']),
+        spent: Number(c['spent']),
+        available: Number(c['balance']),
+        isIncome: g.is_income === true,
+      }))
   );
 }
 

--- a/tests/unit/actual/queries.budget.test.ts
+++ b/tests/unit/actual/queries.budget.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getBudgetStatus } from '../../../src/actual/queries';
+import { actualApi } from '../../../src/actual/client';
+
+vi.mock('../../../src/actual/client', () => ({
+  actualApi: { getBudgetMonth: vi.fn(), getCategoryGroups: vi.fn() },
+}));
+vi.mock('../../../src/logger', () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('getBudgetStatus', () => {
+  it('excludes hidden categories and categories in hidden groups', async () => {
+    // Authoritative visibility source.
+    (actualApi.getCategoryGroups as any).mockResolvedValue([
+      { name: 'Food', hidden: false, categories: [
+        { id: 'c1', name: 'Groceries', hidden: false },
+        { id: 'c2', name: 'OldSnacks', hidden: true },
+      ]},
+      { name: 'Archived', hidden: true, categories: [{ id: 'c3', name: 'X', hidden: false }] },
+    ]);
+    // Budget month returns everything, including the hidden ones.
+    (actualApi.getBudgetMonth as any).mockResolvedValue({
+      categoryGroups: [
+        { is_income: false, categories: [
+          { id: 'c1', name: 'Groceries', budgeted: 10000, spent: -4300, balance: 5700 },
+          { id: 'c2', name: 'OldSnacks', budgeted: 0, spent: 0, balance: 0 },
+        ]},
+        { is_income: false, categories: [
+          { id: 'c3', name: 'X', budgeted: 0, spent: 0, balance: 0 },
+        ]},
+      ],
+    });
+
+    const result = await getBudgetStatus('2026-06');
+
+    expect(result).toEqual([
+      { id: 'c1', name: 'Groceries', budgeted: 10000, spent: -4300, available: 5700, isIncome: false },
+    ]);
+  });
+
+  it('defaults the month and maps balance to available', async () => {
+    (actualApi.getCategoryGroups as any).mockResolvedValue([
+      { name: 'Income', hidden: false, categories: [{ id: 'i1', name: 'Paycheck', hidden: false }] },
+    ]);
+    (actualApi.getBudgetMonth as any).mockResolvedValue({
+      categoryGroups: [
+        { is_income: true, categories: [{ id: 'i1', name: 'Paycheck', budgeted: 0, spent: 250000, balance: 250000 }] },
+      ],
+    });
+
+    const result = await getBudgetStatus();
+
+    expect(actualApi.getBudgetMonth).toHaveBeenCalledOnce();
+    expect(result).toEqual([
+      { id: 'i1', name: 'Paycheck', budgeted: 0, spent: 250000, available: 250000, isIncome: true },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

`getBudgetStatus()` returned **every** category from `getBudgetMonth()` — including hidden categories and categories inside hidden groups — with no visibility filter (unlike `getCategories()`, which filters `hidden`). `getBudgetMonth()`'s category objects don't carry a reliable `hidden` flag, so the filter couldn't be applied inline.

These hidden/archived categories leaked through `GET /budget/status` and the `get_budget_status` MCP tool into the categorization prompt (visible as duplicate/superseded entries like `Netflix (2)`, `Giving (2)`, `Xfinity Internet/Cable (2)`), so Hermes was shown stale categories.

## Fix

Cross-reference `getCategoryGroups()` — the authoritative visibility source already trusted by `getCategories()` — to build a set of non-hidden category ids, then filter budget status to those. Mirrors the existing category-visibility logic.

## Test plan

- [x] New unit tests: hidden category + hidden-group category excluded; month defaulting + `balance → available` mapping
- [x] Full suite: 106 passed
- [x] `tsc` build clean
- [ ] After deploy: `GET /budget/status` no longer lists hidden categories; `(2)`-suffixed duplicates gone from the categorization prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)