### PR TITLE
docs(n8n): Budget Categorize + Consult Pennyworth bootstrap templates

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -25,8 +25,6 @@ Schedule Trigger (daily 08:00)
   → Sync Accounts            POST {GATEWAY_URL}/accounts/sync   (Continue on Fail)
   → Get Uncategorized        GET  {GATEWAY_URL}/tx/uncategorized
   → No Transactions (IF)     length == 0 ? stop (silent) : continue
-  → [ Get Categories ‖ Get Budget Status ]   (both executeOnce — see note)
-  → Merge Context
   → Build Prompt             Code: emits bishop_instruction + bishop_payload
   → Call 'Consult Pennyworth'  Execute Sub-workflow
 
@@ -36,10 +34,13 @@ Consult Pennyworth:
                                   | hermes send --to telegram:$PENNYWORTH_TELEGRAM_CHAT_ID --quiet
 ```
 
-**Why `executeOnce` on the two GET nodes:** the IF node forwards one item per
-uncategorized transaction. Without `executeOnce`, those HTTP nodes would fire
-once per transaction (N× fan-out). `executeOnce` makes each run a single time;
-`Build Prompt` then re-aggregates everything with `$('node').all()`.
+**Categories/budget come from MCP, not the prompt.** n8n only fetches the
+transaction list. `bishop_instruction` tells pennyworth to call the
+budget-gateway MCP tools itself — `list_categories` (apply the leaf name only)
+and, if useful, `get_budget_status`. This keeps the n8n workflow simple (no
+category/budget pre-fetch, no fan-out), keeps the MCP gateway as the single
+source of truth for categories, and lets pennyworth pull budget context only
+when it needs it.
 
 **Why a sub-workflow for delivery:** mirrors the proven `Consult Cato` pattern.
 Keeping the SSH/Hermes/Telegram step in one reusable workflow isolates the

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -1,0 +1,85 @@
+# n8n workflows — Budget Categorize
+
+The scheduled automation that runs the budget agent end to end: sync accounts,
+find uncategorized transactions, gather context, and hand them to the
+`pennyworth` Hermes profile to categorize via the gateway's MCP endpoint.
+
+## Source of truth
+
+These two JSON files are **bootstrap templates only** — so a fresh n8n can be
+brought up by import. Once a workflow is running, **n8n itself is the source of
+truth** (including its version history). Don't hand-edit these files to change a
+live workflow; use the n8n UI or the n8n-mcp tools
+(`n8n_update_partial_workflow`, etc.). Re-export on demand with
+`n8n_get_workflow` if you want to refresh the templates.
+
+| File | Workflow | Role |
+|---|---|---|
+| `budget-categorize.json` | **Budget Categorize** | Daily trigger + context builder (9 nodes) |
+| `consult-pennyworth.json` | **Consult Pennyworth** | Reusable delivery sub-workflow: SSH → `hermes -p pennyworth` → Telegram (2 nodes) |
+
+## Flow
+
+```
+Schedule Trigger (daily 08:00)
+  → Sync Accounts            POST {GATEWAY_URL}/accounts/sync   (Continue on Fail)
+  → Get Uncategorized        GET  {GATEWAY_URL}/tx/uncategorized
+  → No Transactions (IF)     length == 0 ? stop (silent) : continue
+  → [ Get Categories ‖ Get Budget Status ]   (both executeOnce — see note)
+  → Merge Context
+  → Build Prompt             Code: emits bishop_instruction + bishop_payload
+  → Call 'Consult Pennyworth'  Execute Sub-workflow
+
+Consult Pennyworth:
+  Input (bishop_instruction, bishop_payload)
+  → Deliver via Pennyworth   SSH: hermes chat -Q -p pennyworth -q "<instruction + payload>"
+                                  | hermes send --to telegram:$PENNYWORTH_TELEGRAM_CHAT_ID --quiet
+```
+
+**Why `executeOnce` on the two GET nodes:** the IF node forwards one item per
+uncategorized transaction. Without `executeOnce`, those HTTP nodes would fire
+once per transaction (N× fan-out). `executeOnce` makes each run a single time;
+`Build Prompt` then re-aggregates everything with `$('node').all()`.
+
+**Why a sub-workflow for delivery:** mirrors the proven `Consult Cato` pattern.
+Keeping the SSH/Hermes/Telegram step in one reusable workflow isolates the
+shell-escaping (`.replace(/[`$]/g, '\\$&')`) and the `hermes` invocation that
+the rest of the homelab already relies on.
+
+## Required n8n environment variables
+
+Settings → Environment (restart n8n after changing):
+
+| Variable | Value |
+|---|---|
+| `GATEWAY_URL` | Base URL of the Actual HTTP Gateway, e.g. `https://budget-agent.mwdavisii.com` (no trailing slash) |
+| `PENNYWORTH_TELEGRAM_CHAT_ID` | Telegram chat id the pennyworth bot replies to |
+
+## Required credentials
+
+| Credential | Type | Used by |
+|---|---|---|
+| `Budget Gateway` | HTTP Header Auth — header `Authorization`, value `Bearer <GATEWAY_TOKEN>` | the 4 HTTP nodes in Budget Categorize |
+| `SSH Password account` | SSH (password) — the Mac running Hermes | `Deliver via Pennyworth` |
+
+`GATEWAY_TOKEN` must equal the gateway's `GATEWAY_TOKEN`. The token lives only in
+the credential (and, for Hermes' own MCP client, in the pennyworth profile's
+`.env` as `BUDGET_MCP_TOKEN`) — never inline in a workflow.
+
+## Importing into a fresh n8n
+
+1. **Import from File** → `consult-pennyworth.json`, then `budget-categorize.json`.
+2. Set the env vars above.
+3. Create the two credentials and select them on the nodes (the JSON uses
+   `REPLACE_*` placeholders for credential / workflow / error-workflow ids).
+4. On `Call 'Consult Pennyworth'`, point the Workflow selector at the imported
+   Consult Pennyworth (replaces `REPLACE_CONSULT_PENNYWORTH_WORKFLOW_ID`).
+5. Set each workflow's Error Workflow (replaces `REPLACE_ERROR_WORKFLOW_ID`).
+6. **Activate** Budget Categorize. The schedule (08:00 daily) is in
+   `America/Chicago` per n8n's instance timezone — adjust the Schedule Trigger
+   if needed.
+
+## Deploying directly (optional)
+
+If n8n-mcp is configured with `N8N_API_URL` + `N8N_API_KEY`, these can be
+created/updated programmatically instead of imported by hand.

--- a/n8n/budget-categorize.json
+++ b/n8n/budget-categorize.json
@@ -74,55 +74,7 @@
     },
     {
       "parameters": {
-        "url": "={{ $env.GATEWAY_URL }}/categories",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpHeaderAuth",
-        "options": {}
-      },
-      "id": "node-get-categories",
-      "name": "Get Categories",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.4,
-      "position": [1120, 192],
-      "executeOnce": true,
-      "credentials": {
-        "httpHeaderAuth": { "id": "REPLACE_BUDGET_GATEWAY_CRED_ID", "name": "Budget Gateway" }
-      }
-    },
-    {
-      "parameters": {
-        "url": "={{ $env.GATEWAY_URL }}/budget/status",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpHeaderAuth",
-        "sendQuery": true,
-        "queryParameters": {
-          "parameters": [
-            { "name": "month", "value": "={{ new Date().toISOString().slice(0,7) }}" }
-          ]
-        },
-        "options": {}
-      },
-      "id": "node-get-budget-status",
-      "name": "Get Budget Status",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.4,
-      "position": [1120, 432],
-      "executeOnce": true,
-      "credentials": {
-        "httpHeaderAuth": { "id": "REPLACE_BUDGET_GATEWAY_CRED_ID", "name": "Budget Gateway" }
-      }
-    },
-    {
-      "parameters": {},
-      "id": "node-merge",
-      "name": "Merge Context",
-      "type": "n8n-nodes-base.merge",
-      "typeVersion": 3.2,
-      "position": [1344, 304]
-    },
-    {
-      "parameters": {
-        "jsCode": "const syncItem = $('Sync Accounts').first();\nconst syncFailed = !!(syncItem && syncItem.json && syncItem.json.error) ||\n  (syncItem && syncItem.json && Array.isArray(syncItem.json.failed) && syncItem.json.failed.length > 0);\n\nconst txArray = $('Get Uncategorized').all().map(i => i.json).filter(t => t && t.id);\n\nconst catGroups = $('Get Categories').all().map(i => i.json);\nconst categoryList = catGroups\n  .map(g => (g.categories || []).map(c => `- ${g.group} / ${c}`).join('\\n'))\n  .filter(Boolean)\n  .join('\\n');\n\nconst budgetData = $('Get Budget Status').all().map(i => i.json);\nconst month = new Date().toISOString().slice(0, 7);\nconst statusRows = budgetData.filter(b => b && !b.isIncome);\nconst overspent = statusRows.filter(b => b.available < 0);\nconst rest = statusRows.filter(b => b.available >= 0)\n  .sort((a, b) => Math.abs(b.spent) - Math.abs(a.spent));\nconst snapshot = [...overspent, ...rest].slice(0, 10)\n  .map(b => `- ${b.name}: $${(b.budgeted / 100).toFixed(2)} budgeted, $${(Math.abs(b.spent) / 100).toFixed(2)} spent, $${(Math.abs(b.available) / 100).toFixed(2)} ${b.available < 0 ? 'over' : 'remaining'}`)\n  .join('\\n');\n\nconst txList = txArray\n  .map((tx, i) => `${i + 1}. ${tx.date}  ${(tx.notes && String(tx.notes).trim()) ? String(tx.notes).trim() : tx.payee}  ${tx.amount < 0 ? '-' : '+'}$${(Math.abs(tx.amount) / 100).toFixed(2)}  (id: ${tx.id})`)\n  .join('\\n');\n\nconst syncNote = syncFailed\n  ? '\\nNote: bank sync returned errors - data may not include the latest imports.\\n'\n  : '';\n\nconst n = txArray.length;\n\nconst bishop_instruction =\n  `You are categorizing ${n} transaction${n !== 1 ? 's' : ''} against this Actual Budget.${syncNote}\\n\\nAvailable categories (call apply_category with the EXACT leaf name only - the part after the last \"/\"):\\n${categoryList}\\n\\nBudget snapshot (${month}):\\n${snapshot}\\n\\nFor each transaction in the payload below, apply the most appropriate category via apply_category, then send me a brief summary grouped by category.`;\n\nconst bishop_payload = txList;\n\nreturn [{ json: { bishop_instruction, bishop_payload, count: n } }];"
+        "jsCode": "const syncItem = $('Sync Accounts').first();\nconst syncFailed = !!(syncItem && syncItem.json && syncItem.json.error) ||\n  (syncItem && syncItem.json && Array.isArray(syncItem.json.failed) && syncItem.json.failed.length > 0);\n\nconst txArray = $('Get Uncategorized').all().map(i => i.json).filter(t => t && t.id);\n\nconst txList = txArray\n  .map((tx, i) => `${i + 1}. ${tx.date}  ${(tx.notes && String(tx.notes).trim()) ? String(tx.notes).trim() : tx.payee}  ${tx.amount < 0 ? '-' : '+'}$${(Math.abs(tx.amount) / 100).toFixed(2)}  (id: ${tx.id})`)\n  .join('\\n');\n\nconst syncNote = syncFailed\n  ? '\\nNote: bank sync returned errors - data may not include the latest imports.\\n'\n  : '';\n\nconst n = txArray.length;\n\nconst bishop_instruction =\n  `You are categorizing ${n} transaction${n !== 1 ? 's' : ''} in this Actual Budget.${syncNote}\\n\\nUse the budget-gateway MCP tools:\\n- Call list_categories first to get the valid category names. Apply categories with the EXACT leaf name only (the part after the last \"/\").\\n- Optionally call get_budget_status for current-month budget context.\\n\\nFor each transaction in the payload below, choose the most appropriate category and apply it via apply_category. Then send me a brief summary grouped by category.`;\n\nconst bishop_payload = txList;\n\nreturn [{ json: { bishop_instruction, bishop_payload, count: n } }];"
       },
       "id": "node-build-prompt",
       "name": "Build Prompt",
@@ -168,15 +120,9 @@
     "No Transactions": {
       "main": [
         [],
-        [
-          { "node": "Get Categories", "type": "main", "index": 0 },
-          { "node": "Get Budget Status", "type": "main", "index": 0 }
-        ]
+        [{ "node": "Build Prompt", "type": "main", "index": 0 }]
       ]
     },
-    "Get Categories": { "main": [[{ "node": "Merge Context", "type": "main", "index": 0 }]] },
-    "Get Budget Status": { "main": [[{ "node": "Merge Context", "type": "main", "index": 1 }]] },
-    "Merge Context": { "main": [[{ "node": "Build Prompt", "type": "main", "index": 0 }]] },
     "Build Prompt": { "main": [[{ "node": "Call 'Consult Pennyworth'", "type": "main", "index": 0 }]] }
   },
   "settings": {

--- a/n8n/budget-categorize.json
+++ b/n8n/budget-categorize.json
@@ -1,0 +1,187 @@
+{
+  "name": "Budget Categorize",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            { "field": "cronExpression", "expression": "0 8 * * *" }
+          ]
+        }
+      },
+      "id": "node-schedule",
+      "name": "Schedule Trigger",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.3,
+      "position": [240, 304]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.GATEWAY_URL }}/accounts/sync",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {}
+      },
+      "id": "node-sync-accounts",
+      "name": "Sync Accounts",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [464, 304],
+      "credentials": {
+        "httpHeaderAuth": { "id": "REPLACE_BUDGET_GATEWAY_CRED_ID", "name": "Budget Gateway" }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.GATEWAY_URL }}/tx/uncategorized",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {}
+      },
+      "id": "node-get-uncategorized",
+      "name": "Get Uncategorized",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [688, 304],
+      "credentials": {
+        "httpHeaderAuth": { "id": "REPLACE_BUDGET_GATEWAY_CRED_ID", "name": "Budget Gateway" }
+      }
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "version": 2, "leftValue": "", "caseSensitive": true, "typeValidation": "strict" },
+          "conditions": [
+            {
+              "id": "cond-1",
+              "leftValue": "={{ $json.length }}",
+              "rightValue": 0,
+              "operator": { "type": "number", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "node-if-no-tx",
+      "name": "No Transactions",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.3,
+      "position": [912, 304]
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.GATEWAY_URL }}/categories",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {}
+      },
+      "id": "node-get-categories",
+      "name": "Get Categories",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [1120, 192],
+      "executeOnce": true,
+      "credentials": {
+        "httpHeaderAuth": { "id": "REPLACE_BUDGET_GATEWAY_CRED_ID", "name": "Budget Gateway" }
+      }
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.GATEWAY_URL }}/budget/status",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            { "name": "month", "value": "={{ new Date().toISOString().slice(0,7) }}" }
+          ]
+        },
+        "options": {}
+      },
+      "id": "node-get-budget-status",
+      "name": "Get Budget Status",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [1120, 432],
+      "executeOnce": true,
+      "credentials": {
+        "httpHeaderAuth": { "id": "REPLACE_BUDGET_GATEWAY_CRED_ID", "name": "Budget Gateway" }
+      }
+    },
+    {
+      "parameters": {},
+      "id": "node-merge",
+      "name": "Merge Context",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3.2,
+      "position": [1344, 304]
+    },
+    {
+      "parameters": {
+        "jsCode": "const syncItem = $('Sync Accounts').first();\nconst syncFailed = !!(syncItem && syncItem.json && syncItem.json.error) ||\n  (syncItem && syncItem.json && Array.isArray(syncItem.json.failed) && syncItem.json.failed.length > 0);\n\nconst txArray = $('Get Uncategorized').all().map(i => i.json).filter(t => t && t.id);\n\nconst catGroups = $('Get Categories').all().map(i => i.json);\nconst categoryList = catGroups\n  .map(g => (g.categories || []).map(c => `- ${g.group} / ${c}`).join('\\n'))\n  .filter(Boolean)\n  .join('\\n');\n\nconst budgetData = $('Get Budget Status').all().map(i => i.json);\nconst month = new Date().toISOString().slice(0, 7);\nconst statusRows = budgetData.filter(b => b && !b.isIncome);\nconst overspent = statusRows.filter(b => b.available < 0);\nconst rest = statusRows.filter(b => b.available >= 0)\n  .sort((a, b) => Math.abs(b.spent) - Math.abs(a.spent));\nconst snapshot = [...overspent, ...rest].slice(0, 10)\n  .map(b => `- ${b.name}: $${(b.budgeted / 100).toFixed(2)} budgeted, $${(Math.abs(b.spent) / 100).toFixed(2)} spent, $${(Math.abs(b.available) / 100).toFixed(2)} ${b.available < 0 ? 'over' : 'remaining'}`)\n  .join('\\n');\n\nconst txList = txArray\n  .map((tx, i) => `${i + 1}. ${tx.date}  ${(tx.notes && String(tx.notes).trim()) ? String(tx.notes).trim() : tx.payee}  ${tx.amount < 0 ? '-' : '+'}$${(Math.abs(tx.amount) / 100).toFixed(2)}  (id: ${tx.id})`)\n  .join('\\n');\n\nconst syncNote = syncFailed\n  ? '\\nNote: bank sync returned errors - data may not include the latest imports.\\n'\n  : '';\n\nconst n = txArray.length;\n\nconst bishop_instruction =\n  `You are categorizing ${n} transaction${n !== 1 ? 's' : ''} against this Actual Budget.${syncNote}\\n\\nAvailable categories (call apply_category with the EXACT leaf name only - the part after the last \"/\"):\\n${categoryList}\\n\\nBudget snapshot (${month}):\\n${snapshot}\\n\\nFor each transaction in the payload below, apply the most appropriate category via apply_category, then send me a brief summary grouped by category.`;\n\nconst bishop_payload = txList;\n\nreturn [{ json: { bishop_instruction, bishop_payload, count: n } }];"
+      },
+      "id": "node-build-prompt",
+      "name": "Build Prompt",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1568, 304]
+    },
+    {
+      "parameters": {
+        "workflowId": {
+          "__rl": true,
+          "value": "REPLACE_CONSULT_PENNYWORTH_WORKFLOW_ID",
+          "mode": "list",
+          "cachedResultName": "Consult Pennyworth"
+        },
+        "workflowInputs": {
+          "mappingMode": "defineBelow",
+          "value": {
+            "bishop_instruction": "={{ $json.bishop_instruction }}",
+            "bishop_payload": "={{ $json.bishop_payload }}"
+          },
+          "matchingColumns": [],
+          "schema": [
+            { "id": "bishop_payload", "displayName": "bishop_payload", "required": false, "defaultMatch": false, "display": true, "canBeUsedToMatch": true, "type": "string", "removed": false },
+            { "id": "bishop_instruction", "displayName": "bishop_instruction", "required": false, "defaultMatch": false, "display": true, "canBeUsedToMatch": true, "type": "string", "removed": false }
+          ],
+          "attemptToConvertTypes": false,
+          "convertFieldsToString": true
+        },
+        "options": {}
+      },
+      "id": "node-call-consult-pennyworth",
+      "name": "Call 'Consult Pennyworth'",
+      "type": "n8n-nodes-base.executeWorkflow",
+      "typeVersion": 1.3,
+      "position": [1776, 304]
+    }
+  ],
+  "connections": {
+    "Schedule Trigger": { "main": [[{ "node": "Sync Accounts", "type": "main", "index": 0 }]] },
+    "Sync Accounts": { "main": [[{ "node": "Get Uncategorized", "type": "main", "index": 0 }]] },
+    "Get Uncategorized": { "main": [[{ "node": "No Transactions", "type": "main", "index": 0 }]] },
+    "No Transactions": {
+      "main": [
+        [],
+        [
+          { "node": "Get Categories", "type": "main", "index": 0 },
+          { "node": "Get Budget Status", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Get Categories": { "main": [[{ "node": "Merge Context", "type": "main", "index": 0 }]] },
+    "Get Budget Status": { "main": [[{ "node": "Merge Context", "type": "main", "index": 1 }]] },
+    "Merge Context": { "main": [[{ "node": "Build Prompt", "type": "main", "index": 0 }]] },
+    "Build Prompt": { "main": [[{ "node": "Call 'Consult Pennyworth'", "type": "main", "index": 0 }]] }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner",
+    "errorWorkflow": "REPLACE_ERROR_WORKFLOW_ID"
+  }
+}

--- a/n8n/consult-pennyworth.json
+++ b/n8n/consult-pennyworth.json
@@ -1,0 +1,47 @@
+{
+  "name": "Consult Pennyworth",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {
+        "workflowInputs": {
+          "values": [
+            { "name": "bishop_payload" },
+            { "name": "bishop_instruction" }
+          ]
+        }
+      },
+      "id": "node-input",
+      "name": "Input",
+      "type": "n8n-nodes-base.executeWorkflowTrigger",
+      "typeVersion": 1.1,
+      "position": [-512, -352]
+    },
+    {
+      "parameters": {
+        "command": "=PATH=/Users/mwdavisii/.local/bin:/opt/homebrew/bin:$PATH hermes chat -Q -p pennyworth -q {{ JSON.stringify((($json.bishop_instruction || '') + '\\n\\nPayload:\\n' + (typeof $json.bishop_payload === 'object' ? JSON.stringify($json.bishop_payload) : ($json.bishop_payload || ''))).slice(0, 16000)).replace(/[`$]/g, '\\\\$&') }} | PATH=/Users/mwdavisii/.local/bin:/opt/homebrew/bin:$PATH hermes send --to telegram:{{ $env.PENNYWORTH_TELEGRAM_CHAT_ID }} --quiet",
+        "cwd": "/Users/mwdavisii/code/productivity/config/scripts"
+      },
+      "id": "node-deliver",
+      "name": "Deliver via Pennyworth",
+      "type": "n8n-nodes-base.ssh",
+      "typeVersion": 1,
+      "position": [-240, -352],
+      "executeOnce": true,
+      "alwaysOutputData": true,
+      "retryOnFail": false,
+      "credentials": {
+        "sshPassword": { "id": "REPLACE_SSH_PASSWORD_CRED_ID", "name": "SSH Password account" }
+      }
+    }
+  ],
+  "connections": {
+    "Input": { "main": [[{ "node": "Deliver via Pennyworth", "type": "main", "index": 0 }]] }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "timezone": "America/Chicago",
+    "callerPolicy": "workflowsFromSameOwner",
+    "errorWorkflow": "REPLACE_ERROR_WORKFLOW_ID"
+  }
+}


### PR DESCRIPTION
## Summary

Checks the two n8n workflows into the repo as importable **bootstrap templates** (Task 8 of the Budget Categorize plan):

- `n8n/budget-categorize.json` — daily trigger + context builder (9 nodes)
- `n8n/consult-pennyworth.json` — reusable SSH → `hermes -p pennyworth` → Telegram delivery sub-workflow (2 nodes)
- `n8n/README.md` — flow diagram, required env vars (`GATEWAY_URL`, `PENNYWORTH_TELEGRAM_CHAT_ID`), credentials (`Budget Gateway`, `SSH Password account`), import steps, and the `executeOnce` / sub-workflow rationale

n8n stays the source of truth — these are for fresh-import / disaster recovery. Environment-specific ids (credentials, sub-workflow, error workflow) are `REPLACE_*` placeholders. No secrets are committed.

## Test plan

- [x] Both JSON files parse (`json.load`) — 9 and 2 nodes
- [ ] Re-import into a scratch n8n verifies the templates round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)