### PR TITLE
feat(gateway): resolve payee names in transaction outputs

### DIFF
--- a/src/actual/queries.ts
+++ b/src/actual/queries.ts
@@ -18,6 +18,7 @@ export interface Transaction {
   date: string;
   amount: number;
   payee: string;
+  payeeName: string;
   category: string | null;
   notes: string | null;
   account: string;
@@ -61,11 +62,20 @@ export async function getCategories(): Promise<CategoryGroupView[]> {
     }));
 }
 
+// Maps payee id -> human-readable payee name. Actual stores payee as a UUID on
+// each transaction; the LLM needs the name to identify and reason about a
+// transaction (e.g. when correcting an already-categorized one).
+async function getPayeeMap(): Promise<Record<string, string>> {
+  const payees = (await actualApi.getPayees()) as Array<{ id: string; name?: string }>;
+  return Object.fromEntries(payees.map((p) => [p.id, p.name ?? '']));
+}
+
 export async function getUncategorizedTransactions(): Promise<Transaction[]> {
   const accounts = await actualApi.getAccounts() as Array<{ id: string; closed: boolean; offbudget: boolean }>;
   const onBudgetIds = accounts.filter((a) => !a.closed && !a.offbudget).map((a) => a.id);
 
   const accountMap = Object.fromEntries(accounts.map((a) => [a.id, (a as any).name as string]));
+  const payeeMap = await getPayeeMap();
 
   const result = await actualApi.runQuery(
     actualApi.q('transactions')
@@ -80,6 +90,7 @@ export async function getUncategorizedTransactions(): Promise<Transaction[]> {
   return (result as { data: Record<string, unknown>[] }).data.map((tx) => {
     const sanitized = sanitizeObject(tx) as Record<string, unknown>;
     sanitized.accountName = accountMap[tx['account'] as string] ?? '';
+    sanitized.payeeName = payeeMap[tx['payee'] as string] ?? '';
     return sanitized as unknown as Transaction;
   });
 }
@@ -92,6 +103,10 @@ export async function getTransactions(filters: {
   amountMin?: number;
   amountMax?: number;
 }): Promise<Transaction[]> {
+  const accounts = (await actualApi.getAccounts()) as Array<{ id: string; name?: string }>;
+  const accountMap = Object.fromEntries(accounts.map((a) => [a.id, a.name ?? '']));
+  const payeeMap = await getPayeeMap();
+
   let query = actualApi.q('transactions')
     .select(['id', 'date', 'amount', 'payee', 'category', 'notes', 'account']);
   if (filters.startDate) query = query.filter({ date: { $gte: filters.startDate } });
@@ -101,7 +116,12 @@ export async function getTransactions(filters: {
   if (filters.amountMin !== undefined) query = query.filter({ amount: { $gte: filters.amountMin } });
   if (filters.amountMax !== undefined) query = query.filter({ amount: { $lte: filters.amountMax } });
   const result = await actualApi.runQuery(query);
-  return (result as { data: Record<string, unknown>[] }).data.map((tx) => sanitizeObject(tx) as unknown as Transaction);
+  return (result as { data: Record<string, unknown>[] }).data.map((tx) => {
+    const sanitized = sanitizeObject(tx) as Record<string, unknown>;
+    sanitized.accountName = accountMap[tx['account'] as string] ?? '';
+    sanitized.payeeName = payeeMap[tx['payee'] as string] ?? '';
+    return sanitized as unknown as Transaction;
+  });
 }
 
 export async function getBudgetStatus(month?: string): Promise<CategoryStatus[]> {

--- a/tests/unit/actual/queries.payees.test.ts
+++ b/tests/unit/actual/queries.payees.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getUncategorizedTransactions, getTransactions } from '../../../src/actual/queries';
+import { actualApi } from '../../../src/actual/client';
+
+vi.mock('../../../src/actual/client', () => {
+  const chain = {
+    filter: vi.fn().mockReturnThis(),
+    options: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+  };
+  return {
+    actualApi: {
+      getAccounts: vi.fn(),
+      getPayees: vi.fn(),
+      runQuery: vi.fn(),
+      q: vi.fn(() => chain),
+    },
+  };
+});
+vi.mock('../../../src/logger', () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('payee name resolution', () => {
+  it('getUncategorizedTransactions resolves payeeName (and accountName) from ids', async () => {
+    (actualApi.getAccounts as any).mockResolvedValue([
+      { id: 'a1', name: 'Checking', closed: false, offbudget: false },
+    ]);
+    (actualApi.getPayees as any).mockResolvedValue([{ id: 'p1', name: 'ST. JUDE' }]);
+    (actualApi.runQuery as any).mockResolvedValue({
+      data: [{ id: 't1', date: '2026-06-22', amount: 76126, payee: 'p1', notes: 'Memo Credit', account: 'a1' }],
+    });
+
+    const result = await getUncategorizedTransactions();
+
+    expect(result[0].payee).toBe('p1');
+    expect(result[0].payeeName).toBe('ST. JUDE');
+    expect(result[0].accountName).toBe('Checking');
+  });
+
+  it('getTransactions resolves payeeName and falls back to empty for an unknown payee id', async () => {
+    (actualApi.getAccounts as any).mockResolvedValue([{ id: 'a1', name: 'Checking' }]);
+    (actualApi.getPayees as any).mockResolvedValue([{ id: 'p1', name: 'ST. JUDE' }]);
+    (actualApi.runQuery as any).mockResolvedValue({
+      data: [
+        { id: 't1', date: '2026-06-22', amount: 76126, payee: 'p1', category: 'c1', notes: '', account: 'a1' },
+        { id: 't2', date: '2026-06-18', amount: -9300, payee: 'pX', category: 'c1', notes: '', account: 'a1' },
+      ],
+    });
+
+    const result = await getTransactions({ amountMin: 0 });
+
+    expect(result[0].payeeName).toBe('ST. JUDE');
+    expect(result[0].accountName).toBe('Checking');
+    expect(result[1].payeeName).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Actual stores `payee` as a UUID on each transaction, so `query_transactions` and `list_uncategorized_transactions` returned opaque ids (`"8c6b5fc4-..."`) instead of merchant names. Hermes/pennyworth couldn't identify a transaction by name — which is what made correcting an already-categorized transaction fail (it couldn't match "St. Jude", and the row was also future-dated/pending so it fell outside a date-bounded query).

## Change

- Add a **`payeeName`** field to the `Transaction` type, resolved from `getPayees()` (same id→name pattern as the existing `accountName`).
- Populate it in `getUncategorizedTransactions` and `getTransactions`.
- `getTransactions` now also fills `accountName` (it was declared on the type but never set at runtime).

Names flow through `/tx/uncategorized`, `/tx/query`, and the `list_uncategorized_transactions` / `query_transactions` MCP tools, so pennyworth can identify transactions by merchant and show real names in summaries (no more `notes` fallback).

## Test plan

- [x] New unit tests: `payeeName` resolved for known payee, empty fallback for unknown id, `accountName` populated (`queries.payees.test.ts`)
- [x] Full suite: 108 passed (14 files)
- [x] `tsc` build clean
- [ ] After deploy: `/tx/uncategorized` and `/tx/query` responses include `payeeName`

🤖 Generated with [Claude Code](https://claude.com/claude-code)